### PR TITLE
Add sshpass to dependencies

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ RUN apt-get install -y \
   rsync \
   php5 \
   php5-mysql \
-  mysql-client-5.5
+  mysql-client-5.5 \
+  sshpass
 RUN \gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
 RUN \curl -sSL https://get.rvm.io | bash -s latest
 RUN echo "source /etc/profile.d/rvm.sh" >> /etc/bash.bashrc

--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ Docker image to run [Wordmove](https://wptools.it/wordmove/).
 * openssh-server
 * curl
 * rsync
+* sshpass
 * wordmove
 * mysql-client-5.5
 * php5


### PR DESCRIPTION
`sshpass` doesn't come with Ubuntu 14.04 ([here's the manifest](http://releases.ubuntu.com/14.04/ubuntu-14.04.5-desktop-amd64.manifest)), so rsync was failing for me.