### PR TITLE
Update RVM's gpg signatures

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,7 @@ RUN apt-get install -y \
   php5-mysql \
   mysql-client-5.5 \
   sshpass
-RUN \gpg --keyserver hkp://keys.gnupg.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3
+RUN \gpg --keyserver hkp://pool.sks-keyservers.net --recv-keys 409B6B1796C275462A1703113804BB82D39DC0E3 7D2BAF1CF37B13E2069D6956105BD0E739499BDB
 RUN \curl -sSL https://get.rvm.io | bash -s latest
 RUN echo "source /etc/profile.d/rvm.sh" >> /etc/bash.bashrc
 RUN /bin/bash -c "source /etc/profile.d/rvm.sh \


### PR DESCRIPTION
Image's build was not working anymore.

Found that GPG keys were outdated, so updted
them following rvm.io instructions.