### PR TITLE
Alpine mount ssh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,11 @@ LABEL maintainers.2="Alessandro Fazzi <alessandro.fazzi@welaika.com>"
 
 ENV WORDMOVE_WORKDIR /html
 
+COPY mount-ssh.sh /bin/mount-ssh.sh
+RUN chmod +x /bin/mount-ssh.sh
+
 RUN apk update && \
-  apk add --no-cache openssh curl rsync mysql-client bash \
+      apk add --no-cache openssh curl rsync mysql-client bash \
                      php7-mysqli php7-phar php7-json php7-mbstring
 
 RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli.phar && \
@@ -16,4 +19,7 @@ RUN curl -O https://raw.githubusercontent.com/wp-cli/builds/gh-pages/phar/wp-cli
 RUN gem install wordmove --version 5.0.2
 
 WORKDIR ${WORDMOVE_WORKDIR}
+
+ENTRYPOINT ["/bin/mount-ssh.sh"]
+
 CMD ["/bin/bash"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ We ship 3 flavours of this container:
 > @since 28 November 2019 `latest` corresponds to `php7`
 
 `php7` is based upon Debian Buster
-`alpine` tag is - really - based upon Alpine Linux 3.10
+`alpine` tag is based upon Alpine Linux 3.10
 `php5` is based upon Ubuntu 14.04
 
 `php5` also ships with:
@@ -34,19 +34,6 @@ We ship 3 flavours of this container:
 * ENV RUBYOPT="-KU -E utf-8:utf-8" (Fix for some mysql sync issues when using old
   db adapter)
 
-## Notable changes
-
-Since the first version of this container, which is now tagged as `php5`, we got some
-potentially breaking changes.
-
-* There is no `wordmove` user anymore. Now Wordmove supports to be invoked from root user,
-  so we've removed some complexity from the container build.
-  See https://github.com/welaika/wordmove/releases/tag/v2.5.1
-* `sshpass` has been removed. It's use is discouraged and deprecated by Wordmove, so it
-  is in this container. We warmly recommend to use safer approaches.
-* `RUBYOPT` is no more exported. It was solving a problem disappeared since using wp-cli
-  by default, so we've removed complexity from the build.
-
 ## How to use
 
 ### To run this image
@@ -54,6 +41,17 @@ potentially breaking changes.
 `docker run -it --rm -v ~/.ssh:/root/.ssh:ro welaika/wordmove`
 
 This starts a shell, with `wordmove` available on the command-line.
+
+### SSH permission caveat
+
+If you are on a Winodws or Linux host, then you could get permission errors
+while trying to use your ssh keys. To work around this problem we've
+a trick for you:
+
+`docker run -it --rm -v ~/.ssh:/tmp/.ssh:ro welaika/wordmove`
+
+Mounting `.ssh/` inside `/tmp/` will tell the image to automatically copy
+it over in `/root/` and to fix permissions.
 
 ### ENV
 
@@ -91,18 +89,18 @@ Compose, with the following four interconnected containers:
 Don't forget to replace `image: mfuezesi/wordmove` with `image:
 welaika/wordmove` to get the latest version of Wordmove.
 
-## Known limitations
+## Notable changes
 
-* If `sql_adapter` is set to `wpcli`, then the movefile must be in the same
-  directory as the WordPress directory. See https://github.com/welaika/wordmove/issues/506
+Since the first version of this container, which is now tagged as `php5`, we got some
+potentially breaking changes.
 
-## TODO
-
-- [x] Release the Alpine version of this image (see: https://github.com/welaika/docker-wordmove/issues/3)
-- [x] Configure Webhooks to build this image on Docker Hub when a new version of
-  the `wordmove` gem is available
-
-🎉
+* There is no `wordmove` user anymore. Now Wordmove supports to be invoked from root user,
+  so we've removed some complexity from the container build.
+  See https://github.com/welaika/wordmove/releases/tag/v2.5.1
+* `sshpass` has been removed. It's use is discouraged and deprecated by Wordmove, so it
+  is in this container. We warmly recommend to use safer approaches.
+* `RUBYOPT` is no more exported. It was solving a problem disappeared since using wp-cli
+  by default, so we've removed complexity from the build.
 
 ## Credits 🙏🏻
 

--- a/README.md
+++ b/README.md
@@ -34,17 +34,17 @@ We ship 3 flavours of this container:
 * ENV RUBYOPT="-KU -E utf-8:utf-8" (Fix for some mysql sync issues when using old
   db adapter)
 
-## How to use
+## Usage
 
-### To run this image
+### Run this image
 
 `docker run -it --rm -v ~/.ssh:/root/.ssh:ro welaika/wordmove`
 
 This starts a shell, with `wordmove` available on the command-line.
 
-### SSH permission caveat
+### SSH permissions caveat
 
-If you are on a Winodws or Linux host, then you could get permission errors
+If you are on a Windows or Linux host, then you could get permission errors
 while trying to use your ssh keys. To work around this problem we've
 a trick for you:
 

--- a/mount-ssh.sh
+++ b/mount-ssh.sh
@@ -1,0 +1,19 @@
+#!/usr/bin/env bash
+set -e
+
+# Using `-v $HOME/.ssh:/root/.ssh:ro` produce permissions error while in the container
+# when working from Linux and maybe from Windows.
+# To prevent that we offer the strategy to mount the `.ssh` folder with
+# `-v $HOME/.ssh:/tmp/.ssh:ro` thus this entrypoint will automatically handle problem.
+
+if [[ -d /tmp/.ssh ]]; then
+
+  cp -R /tmp/.ssh /root/.ssh
+  chmod 700 /root/.ssh
+  chmod 600 /root/.ssh/*
+  chmod 644 /root/.ssh/*.pub
+  chmod 644 /root/.ssh/known_hosts
+
+fi
+
+exec "$@"


### PR DESCRIPTION
This work is born from https://github.com/welaika/docker-wordmove/issues/16

The goal is to guarantee a solid solution to work around `.ssh/` folder permission problem that could arise working under Linux or Windows.

We introduced an entrypoint that will search for `/tmp/.ssh/` folder and if it exists it will be copied over to `/root/` with fixed permission.

We support multiple keys inside your `~/.ssh/` and we manage `known_hosts` permissions too.

README updated with instructions.